### PR TITLE
feat(storage): add paginated file list endpoint

### DIFF
--- a/document/api-documentation.md
+++ b/document/api-documentation.md
@@ -1,267 +1,1136 @@
-# API 接口文档
+# Janus Eye API 接口文档
 
-## 概述
+本文档详细描述了 Janus Eye 教学平台的后端 API 接口，旨在为前端开发人员提供清晰、准确的对接指南。
 
-本文档描述了 Janus Eye 教学平台的 API 接口规范。所有 API 接口均基于 RESTful 架构设计，使用 JSON 格式进行数据交互。
+**最后更新时间**: 2025-07-05
 
-**基础 URL**: `http://localhost:3001/api`
+## 目录
+- [通用数据结构](#通用数据结构)
+- [1. 统计接口 (`StatsController`)](#1-统计接口-statscontroller)
+- [2. 存储接口 (`StorageController`)](#2-存储接口-storagecontroller)
+- [3. AI 接口 (`EmbeddingController`)](#3-ai-接口-embeddingcontroller)
+- [4. 课程接口 (`CourseController`)](#4-课程接口-coursecontroller)
+- [5. 作业接口 (`AssignmentController`)](#5-作业接口-assignmentcontroller)
+- [6. 题目接口 (`QuestionController`)](#6-题目接口-questioncontroller)
+- [7. 通知接口 (`NotificationController`)](#7-通知接口-notificationcontroller)
 
-## 接口列表
+---
 
-### 1. 用户管理 (User Management)
+## 通用数据结构
 
-#### 1.1 获取所有用户
-- **接口地址**: `GET /users`
-- **接口描述**: 获取系统中所有用户信息
-- **请求参数**: 无
-- **响应格式**: 
-  ```json
-  [
+### `UserVO`
+代表一个用户的公开视图信息。
+
+**Kotlin 定义**
+```kotlin
+data class UserVO(
+    val id: UUID,
+    val displayName: String?,
+    val avatarUrl: String?,
+    val role: String
+)
+```
+**JSON 示例**
+```json
+{
+  "id": "a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11",
+  "displayName": "John Doe",
+  "avatarUrl": "https://example.com/avatar.png",
+  "role": "STUDENT"
+}
+```
+
+### `PageVO<T>`
+用于分页查询的响应结构。
+
+**Kotlin 定义**
+```kotlin
+data class PageVO<T>(
+    val content: List<T>,      // 当前页数据
+    val totalElements: Long, // 总元素数
+    val totalPages: Int,     // 总页数
+    val size: Int,           // 每页大小
+    val number: Int          // 当前页码 (从0开始)
+)
+```
+**JSON 示例 (以 `UserVO` 为例)**
+```json
+{
+  "content": [
     {
-      "id": "string",
-      "name": "string",
-      "email": "string",
-      "avatar": "string",
-      "role": "teacher" | "student" | "admin"
+      "id": "a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11",
+      "displayName": "John Doe",
+      "avatarUrl": "https://example.com/avatar.png",
+      "role": "STUDENT"
     }
-  ]
-  ```
+  ],
+  "totalElements": 1,
+  "totalPages": 1,
+  "size": 20,
+  "number": 0
+}
+```
 
-### 2. 课程管理 (Course Management)
+### `StatusVO`
+通用的操作状态响应。
 
-#### 2.1 获取所有课程
-- **接口地址**: `GET /courses`
-- **接口描述**: 获取系统中所有课程信息
+**Kotlin 定义**
+```kotlin
+data class StatusVO(
+    val status: String,
+    val message: String
+)
+```
+**JSON 示例**
+```json
+{
+  "status": "success",
+  "message": "Operation completed successfully."
+}
+```
+
+### `MessageVO`
+通用的消息响应。
+
+**Kotlin 定义**
+```kotlin
+data class MessageVO(
+    val message: String
+)
+```
+**JSON 示例**
+```json
+{
+  "message": "All notifications marked as read"
+}
+```
+
+---
+
+## 1. 统计接口 (`StatsController`)
+**基础路径**: `/api/stats`
+
+### 1.1 获取性能统计
+- **描述**: 获取平台整体的性能统计数据，例如平均正确率和常见错误概念。
+- **Endpoint**: `GET /api/stats`
+- **认证**: 需要
 - **请求参数**: 无
-- **响应格式**:
-  ```json
-  [
+- **响应**: `200 OK`
+  - **Body**: `PerformanceStatsVO`
+    **Kotlin 定义**
+    ```kotlin
+    data class PerformanceStatsVO(
+        val averageAccuracy: Double,         // 平均正确率
+        val frequentlyMissedConcepts: List<String> // 常见错误概念列表
+    )
+    ```
+    **JSON 示例**
+    ```json
     {
-      "id": "string",
-      "name": "string",
-      "description": "string",
-      "teacher": "string",
-      "students": "number",
-      "progress": "number",
-      "image": "string" (可选)
+      "averageAccuracy": 0.95,
+      "frequentlyMissedConcepts": ["数据结构", "算法"]
     }
-  ]
-  ```
+    ```
 
-### 3. 题目管理 (Question Management)
+---
 
-#### 3.1 获取所有题目
-- **接口地址**: `GET /questions`
-- **接口描述**: 获取系统中所有题目信息
-- **请求参数**: 无
-- **响应格式**:
-  ```json
-  [
+## 2. 存储接口 (`StorageController`)
+**基础路径**: `/api/storage`
+
+### 2.1 上传文件
+- **描述**: 上传一个文件到对象存储服务(OSS)。
+- **Endpoint**: `POST /api/storage/upload`
+- **认证**: 需要
+- **请求参数**:
+  - **类型**: `multipart/form-data`
+  - **参数**:
+    - `file`: `MultipartFile` (必需) - 要上传的文件。
+    - `uploaderId`: `UUID` (必需) - 上传者的用户ID。
+- **响应**: `200 OK`
+  - **Body**: `StorageObjectVO`
+
+### 2.2 获取文件详情
+- **描述**: 根据文件ID获取文件的详细信息。
+- **Endpoint**: `GET /api/storage/{id}`
+- **认证**: 需要
+- **请求参数**:
+  - **路径参数**:
+    - `id`: `UUID` (必需) - 文件ID。
+- **响应**:
+  - `200 OK`: `StorageObjectVO`
+  - `404 Not Found`: 如果文件不存在。
+
+### 2.3 请求文件向量化
+- **描述**: 异步请求对已上传的文件进行向量化处理。
+- **Endpoint**: `POST /api/storage/{id}/embed`
+- **认证**: 需要
+- **请求参数**:
+  - **路径参数**:
+    - `id`: `UUID` (必需) - 文件ID。
+- **响应**: `202 Accepted`
+  - **Body**: `StatusVO` (告知请求已被接受并排队处理)
+
+### 2.4 获取文件列表 (分页)
+- **描述**: 根据条件分页获取文件列表。普通用户默认只能看到自己上传的文件，管理员可以看到所有文件。
+- **Endpoint**: `GET /api/storage`
+- **认证**: 需要
+- **查询参数**:
+  - `currentUserId`: `UUID` (必需) - 当前操作用户的ID。**注意**: 这是一个临时的身份验证方案，在未来的版本中将被替换为基于令牌的安全上下文。
+  - `uploaderId`: `UUID` (可选) - 按上传者ID筛选。仅管理员可用。
+  - `keyword`: `String` (可选) - 按文件名进行模糊搜索。
+  - `page`: `Int` (可选, 默认 `0`) - 页码。
+  - `size`: `Int` (可选, 默认 `20`) - 每页大小。
+- **响应**: `200 OK`
+  - **Body**: `PageVO<StorageObjectVO>` (结构参考[通用数据结构](#PageVO<T>))
+
+### `StorageObjectVO`
+**Kotlin 定义**
+```kotlin
+data class StorageObjectVO(
+    val id: UUID,
+    val objectKey: String,
+    val originalFilename: String,
+    val fileSize: Long,
+    val contentType: String?,
+    val storageProvider: String,
+    val bucketName: String,
+    val embeddingStatus: EmbeddingStatus, // (NOT_STARTED, IN_PROGRESS, COMPLETED, FAILED)
+    val uploader: UserVO?,
+    val createdAt: LocalDateTime?,
+    val updatedAt: LocalDateTime?
+)
+```
+**JSON 示例**
+```json
+{
+  "id": "123e4567-e89b-12d3-a456-426614174000",
+  "objectKey": "uploads/myfile.pdf",
+  "originalFilename": "myfile.pdf",
+  "fileSize": 102400,
+  "contentType": "application/pdf",
+  "storageProvider": "minio",
+  "bucketName": "janus",
+  "embeddingStatus": "COMPLETED",
+  "uploader": {
+    "id": "a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11",
+    "displayName": "Jane Doe",
+    "avatarUrl": "https://example.com/avatar.png",
+    "role": "TEACHER"
+  },
+  "createdAt": "2025-07-05T10:00:00Z",
+  "updatedAt": "2025-07-05T10:05:00Z"
+}
+```
+
+---
+
+## 3. AI 接口 (`EmbeddingController`)
+**基础路径**: `/ai`
+
+### 3.1 文本向量化并存储
+- **描述**: 将给定的文本进行向量化并存储到向量数据库。
+- **Endpoint**: `POST /ai/embedding/store`
+- **认证**: 需要
+- **请求**:
+  - **Body**: `EmbeddingRequest`
+    **Kotlin 定义**
+    ```kotlin
+    data class EmbeddingRequest(
+        val message: String // 需要向量化的文本
+    )
+    ```
+    **JSON 示例**
+    ```json
     {
-      "id": "string",
-      "title": "string",
-      "type": "multiple-choice" | "true-false" | "short-answer" | "essay",
-      "difficulty": "easy" | "medium" | "hard",
-      "knowledgePoints": ["string"],
-      "options": ["string"] (可选),
-      "correctAnswer": "string | number" (可选),
-      "explanation": "string" (可选)
+      "message": "This is a text to be embedded."
     }
-  ]
-  ```
+    ```
+- **响应**: `200 OK`
+  - **Body**: `StatusVO` (告知操作成功)
 
-### 4. 作业管理 (Assignment Management)
-
-#### 4.1 获取所有作业
-- **接口地址**: `GET /assignments`
-- **接口描述**: 获取系统中所有作业信息
-- **请求参数**: 无
-- **响应格式**:
-  ```json
-  [
+### 3.2 文本向量化
+- **描述**: 对给定的文本进行向量化，直接返回向量结果。
+- **Endpoint**: `POST /ai/embedding`
+- **认证**: 需要
+- **请求**:
+  - **Body**: `EmbeddingRequest`
+- **响应**: `200 OK`
+  - **Body**: `EmbeddingVO`
+    **Kotlin 定义**
+    ```kotlin
+    data class EmbeddingVO(
+        // Spring AI 的 EmbeddingResponse，通常包含一个浮点数数组
+        val embedding: EmbeddingResponse
+    )
+    ```
+    **JSON 示例**
+    ```json
     {
-      "id": "string",
-      "title": "string",
-      "description": "string",
-      "dueDate": "string",
-      "courseId": "string",
-      "questions": [Question对象],
-      "submissions": "number",
-      "maxScore": "number"
+      "embedding": {
+        "embedding": [0.1, 0.2, 0.3],
+        "metadata": {}
+      }
     }
-  ]
+    ```
+
+---
+
+## 4. 课程接口 (`CourseController`)
+**基础路径**: `/api/courses`
+
+### 4.1 创建课程
+- **Endpoint**: `POST /api/courses`
+- **请求 Body**: `CreateCourseDto`
+  **Kotlin 定义**
+  ```kotlin
+  data class CreateCourseDto(
+      val name: String,         // 课程名称
+      val description: String?, // 课程描述
+      val teacherId: UUID,      // 教师ID
+      val coverImageUrl: String?  // 封面图片URL
+  )
   ```
-
-### 5. 通知管理 (Notification Management)
-
-#### 5.1 获取所有通知
-- **接口地址**: `GET /notifications`
-- **接口描述**: 获取系统中所有通知信息
-- **请求参数**: 无
-- **响应格式**:
-  ```json
-  [
-    {
-      "id": "string",
-      "title": "string",
-      "content": "string",
-      "type": "info" | "warning" | "success" | "error",
-      "isRead": "boolean",
-      "createdAt": "string",
-      "avatar": "string" (可选)
-    }
-  ]
-  ```
-
-### 6. 统计数据 (Statistics)
-
-#### 6.1 获取性能统计数据
-- **接口地址**: `GET /stats`
-- **接口描述**: 获取学生学习性能统计数据
-- **请求参数**: 无
-- **响应格式**:
+  **JSON 示例**
   ```json
   {
-    "averageAccuracy": "number",
-    "frequentlyMissedConcepts": ["string"],
-    "classRanking": "string",
-    "knowledgePointMastery": {
-      "知识点名称": "number"
+    "name": "Introduction to Kotlin",
+    "description": "A comprehensive course on Kotlin programming.",
+    "teacherId": "a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11",
+    "coverImageUrl": "https://example.com/course_cover.png"
+  }
+  ```
+- **响应**: `201 Created` - `CourseVO`
+
+### 4.2 获取课程详情
+- **Endpoint**: `GET /api/courses/{id}`
+- **路径参数**: `id: UUID` (课程ID)
+- **响应**: `200 OK` - `CourseVO`
+
+### 4.3 获取课程列表
+- **Endpoint**: `GET /api/courses`
+- **查询参数**:
+  - `teacherId: UUID` (可选) - 按教师ID筛选
+  - `studentId: UUID` (可选) - 按学生ID筛选
+  - `keyword: String` (可选) - 按名称或描述搜索
+- **响应**: `200 OK` - `List<CourseVO>`
+
+### 4.4 更新课程
+- **Endpoint**: `PUT /api/courses/{id}`
+- **路径参数**: `id: UUID` (课程ID)
+- **请求 Body**: `UpdateCourseDto`
+  **Kotlin 定义**
+  ```kotlin
+  data class UpdateCourseDto(
+      val name: String?,
+      val description: String?,
+      val coverImageUrl: String?
+  )
+  ```
+  **JSON 示例**
+  ```json
+  {
+    "name": "Advanced Kotlin",
+    "description": "An advanced course on Kotlin programming and coroutines."
+  }
+  ```
+- **响应**: `200 OK` - `CourseVO`
+
+### 4.5 删除课程
+- **Endpoint**: `DELETE /api/courses/{id}`
+- **路径参数**: `id: UUID` (课程ID)
+- **响应**: `204 No Content`
+
+### 4.6 学生选课
+- **Endpoint**: `POST /api/courses/{id}/enroll`
+- **路径参数**: `id: UUID` (课程ID)
+- **请求 Body**: `EnrollmentDto`
+  **Kotlin 定义**
+  ```kotlin
+  data class EnrollmentDto(
+      val studentId: UUID
+  )
+  ```
+  **JSON 示例**
+  ```json
+  {
+    "studentId": "b1eebc99-9c0b-4ef8-bb6d-6bb9bd380a12"
+  }
+  ```
+- **响应**: `200 OK` - `CourseVO`
+
+### 4.7 学生退课
+- **Endpoint**: `DELETE /api/courses/{id}/enroll/{studentId}`
+- **路径参数**:
+  - `id: UUID` (课程ID)
+  - `studentId: UUID` (学生ID)
+- **响应**: `200 OK` - `CourseVO`
+
+### 4.8 获取课程学生列表
+- **Endpoint**: `GET /api/courses/{id}/students`
+- **路径参数**: `id: UUID` (课程ID)
+- **响应**: `200 OK` - `List<UserVO>`
+
+### 4.9 获取课程统计
+- **Endpoint**: `GET /api/courses/{id}/stats`
+- **路径参数**: `id: UUID` (课程ID)
+- **响应**: `200 OK` - `CourseStatsVO`
+
+### 响应/请求体定义
+- `CourseVO`
+  **Kotlin 定义**
+  ```kotlin
+  data class CourseVO(
+      val id: UUID,
+      val name: String,
+      val description: String?,
+      val coverImageUrl: String?,
+      val teacher: UserVO,
+      val studentCount: Long, // 学生数量
+      val createdAt: LocalDateTime?,
+      val updatedAt: LocalDateTime?
+  )
+  ```
+  **JSON 示例**
+  ```json
+  {
+    "id": "c2eebc99-9c0b-4ef8-bb6d-6bb9bd380a13",
+    "name": "Introduction to Kotlin",
+    "description": "A comprehensive course on Kotlin programming.",
+    "coverImageUrl": "https://example.com/course_cover.png",
+    "teacher": {
+      "id": "a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11",
+      "displayName": "Jane Doe",
+      "avatarUrl": "https://example.com/avatar.png",
+      "role": "TEACHER"
     },
-    "accuracyTrends": [
+    "studentCount": 50,
+    "createdAt": "2025-07-01T09:00:00Z",
+    "updatedAt": "2025-07-01T09:00:00Z"
+  }
+  ```
+- `CourseStatsVO`
+  **Kotlin 定义**
+  ```kotlin
+  data class CourseStatsVO(
+      val id: UUID,
+      val name: String,
+      val studentCount: Long,
+      val teacher: UserVO,
+      val createdAt: String
+  )
+  ```
+  **JSON 示例**
+  ```json
+  {
+    "id": "c2eebc99-9c0b-4ef8-bb6d-6bb9bd380a13",
+    "name": "Introduction to Kotlin",
+    "studentCount": 50,
+    "teacher": {
+      "id": "a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11",
+      "displayName": "Jane Doe",
+      "avatarUrl": "https://example.com/avatar.png",
+      "role": "TEACHER"
+    },
+    "createdAt": "2025-07-01T09:00:00Z"
+  }
+  ```
+
+---
+
+## 5. 作业接口 (`AssignmentController`)
+**基础路径**: `/api/assignments`
+
+### 5.1 创建作业
+- **Endpoint**: `POST /api/assignments`
+- **请求 Body**: `CreateAssignmentDto`
+  **Kotlin 定义**
+  ```kotlin
+  data class CreateAssignmentDto(
+      val title: String,
+      val description: String?,
+      val courseId: UUID,
+      val creatorId: UUID,
+      val dueDate: LocalDateTime?, // 截止日期
+      val questionIds: List<UUID>  // 题目ID列表
+  )
+  ```
+  **JSON 示例**
+  ```json
+  {
+    "title": "Week 1 Assignment",
+    "description": "Questions about basic Kotlin syntax.",
+    "courseId": "c2eebc99-9c0b-4ef8-bb6d-6bb9bd380a13",
+    "creatorId": "a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11",
+    "dueDate": "2025-07-15T23:59:59Z",
+    "questionIds": [
+      "d3eebc99-9c0b-4ef8-bb6d-6bb9bd380a14",
+      "e4eebc99-9c0b-4ef8-bb6d-6bb9bd380a15"
+    ]
+  }
+  ```
+- **响应**: `201 Created` - `AssignmentVO`
+
+### 5.2 获取作业详情
+- **Endpoint**: `GET /api/assignments/{id}`
+- **路径参数**: `id: UUID`
+- **响应**: `200 OK` - `AssignmentVO`
+
+### 5.3 获取作业列表
+- **Endpoint**: `GET /api/assignments`
+- **查询参数**:
+  - `courseId: UUID` (可选)
+  - `creatorId: UUID` (可选)
+  - `studentId: UUID` (可选)
+- **响应**: `200 OK` - `List<AssignmentVO>`
+
+### 5.4 更新作业
+- **Endpoint**: `PUT /api/assignments/{id}`
+- **路径参数**: `id: UUID`
+- **请求 Body**: `UpdateAssignmentDto`
+  **Kotlin 定义**
+  ```kotlin
+  data class UpdateAssignmentDto(
+      val title: String?,
+      val description: String?,
+      val dueDate: LocalDateTime?,
+      val questionIds: List<UUID>?
+  )
+  ```
+  **JSON 示例**
+  ```json
+  {
+    "title": "Week 1 Assignment (Updated)",
+    "dueDate": "2025-07-16T23:59:59Z"
+  }
+  ```
+- **响应**: `200 OK` - `AssignmentVO`
+
+### 5.5 删除作业
+- **Endpoint**: `DELETE /api/assignments/{id}`
+- **路径参数**: `id: UUID`
+- **响应**: `204 No Content`
+
+### 5.6 提交作业
+- **Endpoint**: `POST /api/assignments/submit`
+- **请求 Body**: `SubmitAssignmentDto`
+  **Kotlin 定义**
+  ```kotlin
+  data class SubmitAssignmentDto(
+      val assignmentId: UUID,
+      val studentId: UUID,
+      val answers: Map<UUID, String> // Map<questionId, answer_content>
+  )
+  ```
+  **JSON 示例**
+  ```json
+  {
+    "assignmentId": "f5eebc99-9c0b-4ef8-bb6d-6bb9bd380a16",
+    "studentId": "b1eebc99-9c0b-4ef8-bb6d-6bb9bd380a12",
+    "answers": {
+      "d3eebc99-9c0b-4ef8-bb6d-6bb9bd380a14": "Answer for question 1",
+      "e4eebc99-9c0b-4ef8-bb6d-6bb9bd380a15": "Answer for question 2"
+    }
+  }
+  ```
+- **响应**: `201 Created` - `AssignmentSubmissionVO`
+
+### 5.7 获取作业的提交列表
+- **Endpoint**: `GET /api/assignments/{id}/submissions`
+- **路径参数**: `id: UUID` (作业ID)
+- **响应**: `200 OK` - `List<AssignmentSubmissionVO>`
+
+### 5.8 获取单个提交详情
+- **Endpoint**: `GET /api/assignments/submissions/{submissionId}`
+- **路径参数**: `submissionId: UUID`
+- **响应**: `200 OK` - `AssignmentSubmissionVO`
+
+### 5.9 批改作业
+- **Endpoint**: `POST /api/assignments/submissions/{submissionId}/grade`
+- **路径参数**: `submissionId: UUID`
+- **请求 Body**: `GradeSubmissionDto`
+  **Kotlin 定义**
+  ```kotlin
+  data class GradeSubmissionDto(
+      val scores: Map<UUID, Boolean> // Map<questionId, isCorrect>
+  )
+  ```
+  **JSON 示例**
+  ```json
+  {
+    "scores": {
+      "d3eebc99-9c0b-4ef8-bb6d-6bb9bd380a14": true,
+      "e4eebc99-9c0b-4ef8-bb6d-6bb9bd380a15": false
+    }
+  }
+  ```
+- **响应**: `200 OK` - `AssignmentSubmissionVO`
+
+### 5.10 获取学生的提交列表
+- **Endpoint**: `GET /api/assignments/student/{studentId}`
+- **路径参数**: `studentId: UUID`
+- **响应**: `200 OK` - `List<AssignmentSubmissionVO>`
+
+### 5.11 获取作业统计
+- **Endpoint**: `GET /api/assignments/{id}/stats`
+- **路径参数**: `id: UUID` (作业ID)
+- **响应**: `200 OK` - `AssignmentStatsVO`
+
+### 5.12 获取课程的作业统计
+- **Endpoint**: `GET /api/assignments/course/{courseId}/stats`
+- **路径参数**: `courseId: UUID`
+- **响应**: `200 OK` - `CourseAssignmentStatsVO`
+
+### 响应/请求体定义
+- `AssignmentVO`
+  **Kotlin 定义**
+  ```kotlin
+  data class AssignmentVO(
+      val id: UUID,
+      val title: String,
+      val description: String?,
+      val course: CourseVO,
+      val creator: UserVO,
+      val questions: List<QuestionVO>,
+      val dueDate: LocalDateTime?,
+      val createdAt: LocalDateTime?,
+      val updatedAt: LocalDateTime?
+  )
+  ```
+  **JSON 示例**
+  ```json
+  {
+    "id": "f5eebc99-9c0b-4ef8-bb6d-6bb9bd380a16",
+    "title": "Week 1 Assignment",
+    "description": "Questions about basic Kotlin syntax.",
+    "course": {
+      "id": "c2eebc99-9c0b-4ef8-bb6d-6bb9bd380a13",
+      "name": "Introduction to Kotlin",
+      "description": "A comprehensive course on Kotlin programming.",
+      "coverImageUrl": "https://example.com/course_cover.png",
+      "teacher": {
+        "id": "a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11",
+        "displayName": "Jane Doe",
+        "avatarUrl": "https://example.com/avatar.png",
+        "role": "TEACHER"
+      },
+      "studentCount": 50,
+      "createdAt": "2025-07-01T09:00:00Z",
+      "updatedAt": "2025-07-01T09:00:00Z"
+    },
+    "creator": {
+      "id": "a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11",
+      "displayName": "Jane Doe",
+      "avatarUrl": "https://example.com/avatar.png",
+      "role": "TEACHER"
+    },
+    "questions": [
       {
-        "week": "string",
-        "accuracy": "number"
+        "id": "d3eebc99-9c0b-4ef8-bb6d-6bb9bd380a14",
+        "type": "SINGLE_CHOICE",
+        "difficulty": "EASY",
+        "content": "What is the keyword for a variable in Kotlin?",
+        "explanation": "`val` is for read-only variables, `var` is for mutable variables.",
+        "knowledgePoints": [
+          {
+            "id": "g6eebc99-9c0b-4ef8-bb6d-6bb9bd380a17",
+            "name": "Variables",
+            "description": "Kotlin variable declaration.",
+            "subject": "Kotlin Basics"
+          }
+        ],
+        "creator": {
+            "id": "a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11",
+            "displayName": "Jane Doe",
+            "avatarUrl": "https://example.com/avatar.png",
+            "role": "TEACHER"
+        },
+        "createdAt": "2025-07-05T11:00:00Z",
+        "updatedAt": "2025-07-05T11:00:00Z"
       }
     ],
-    "questionTypeDistribution": [
+    "dueDate": "2025-07-15T23:59:59Z",
+    "createdAt": "2025-07-08T14:00:00Z",
+    "updatedAt": "2025-07-08T14:00:00Z"
+  }
+  ```
+- `AssignmentSubmissionVO`
+  **Kotlin 定义**
+  ```kotlin
+  data class AssignmentSubmissionVO(
+      val id: UUID,
+      val assignment: AssignmentBriefVO,
+      val student: UserVO,
+      val answers: List<SubmissionAnswerVO>,
+      val score: BigDecimal?,
+      val status: SubmissionStatus, // (PENDING, SUBMITTED, GRADED)
+      val submittedAt: LocalDateTime?
+  )
+  ```
+  **JSON 示例**
+  ```json
+  {
+    "id": "h7eebc99-9c0b-4ef8-bb6d-6bb9bd380a18",
+    "assignment": {
+      "id": "f5eebc99-9c0b-4ef8-bb6d-6bb9bd380a16",
+      "title": "Week 1 Assignment",
+      "dueDate": "2025-07-15T23:59:59Z"
+    },
+    "student": {
+      "id": "b1eebc99-9c0b-4ef8-bb6d-6bb9bd380a12",
+      "displayName": "John Doe",
+      "avatarUrl": "https://example.com/avatar.png",
+      "role": "STUDENT"
+    },
+    "answers": [
       {
-        "type": "string",
-        "percentage": "number"
+        "id": "i8eebc99-9c0b-4ef8-bb6d-6bb9bd380a19",
+        "question": { "id": "d3eebc99-9c0b-4ef8-bb6d-6bb9bd380a14", "...": "..." },
+        "answer": "Answer for question 1",
+        "isCorrect": true
+      }
+    ],
+    "score": 100.0,
+    "status": "GRADED",
+    "submittedAt": "2025-07-10T10:00:00Z"
+  }
+  ```
+- `AssignmentStatsVO`
+  **Kotlin 定义**
+  ```kotlin
+  data class AssignmentStatsVO(
+      val id: UUID,
+      val title: String,
+      val totalStudents: Long,
+      val submissionCount: Long,
+      val gradedCount: Long,
+      val submissionRate: Double,
+      val averageScore: BigDecimal?
+  )
+  ```
+  **JSON 示例**
+  ```json
+  {
+    "id": "f5eebc99-9c0b-4ef8-bb6d-6bb9bd380a16",
+    "title": "Week 1 Assignment",
+    "totalStudents": 50,
+    "submissionCount": 45,
+    "gradedCount": 40,
+    "submissionRate": 90.0,
+    "averageScore": 85.5
+  }
+  ```
+- `CourseAssignmentStatsVO`
+  **Kotlin 定义**
+  ```kotlin
+  data class CourseAssignmentStatsVO(
+      val courseId: UUID,
+      val totalAssignments: Int,
+      val totalSubmissions: Long,
+      val assignments: List<AssignmentStatVO>
+  )
+  ```
+  **JSON 示例**
+  ```json
+  {
+    "courseId": "c2eebc99-9c0b-4ef8-bb6d-6bb9bd380a13",
+    "totalAssignments": 5,
+    "totalSubmissions": 225,
+    "assignments": [
+      {
+        "id": "f5eebc99-9c0b-4ef8-bb6d-6bb9bd380a16",
+        "title": "Week 1 Assignment",
+        "submissionCount": 45,
+        "dueDate": "2025-07-15T23:59:59Z"
       }
     ]
   }
   ```
 
-### 7. 教学大纲 (Syllabus)
+---
 
-#### 7.1 获取教学大纲
-- **接口地址**: `GET /syllabus`
-- **接口描述**: 获取课程教学大纲信息
-- **请求参数**: 无
-- **响应格式**:
+## 6. 题目接口 (`QuestionController`)
+**基础路径**: `/api/questions`
+
+### 6.1 创建题目
+- **Endpoint**: `POST /api/questions`
+- **请求 Body**: `CreateQuestionDto`
+  **Kotlin 定义**
+  ```kotlin
+  data class CreateQuestionDto(
+      val type: QuestionType, // (SINGLE_CHOICE, MULTIPLE_CHOICE, TRUE_FALSE, FILL_IN_BLANK, SHORT_ANSWER)
+      val difficulty: Difficulty, // (EASY, MEDIUM, HARD)
+      val content: String,
+      val correctAnswer: String?,
+      val explanation: String?,
+      val knowledgePointIds: Set<UUID>,
+      val creatorId: UUID
+  )
+  ```
+  **JSON 示例**
   ```json
   {
-    "id": "string",
-    "courseId": "string",
-    "chapters": [
+    "type": "SINGLE_CHOICE",
+    "difficulty": "EASY",
+    "content": "What is the keyword for a read-only variable in Kotlin?",
+    "correctAnswer": "val",
+    "explanation": "`val` is used for immutable variables.",
+    "knowledgePointIds": ["g6eebc99-9c0b-4ef8-bb6d-6bb9bd380a17"],
+    "creatorId": "a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11"
+  }
+  ```
+- **响应**: `201 Created` - `QuestionVO`
+
+### 6.2 获取题目详情
+- **Endpoint**: `GET /api/questions/{id}`
+- **路径参数**: `id: UUID`
+- **响应**: `200 OK` - `QuestionVO`
+
+### 6.3 获取题目列表 (分页)
+- **Endpoint**: `GET /api/questions`
+- **查询参数**:
+  - `type: QuestionType` (可选)
+  - `difficulty: Difficulty` (可选)
+  - `creatorId: UUID` (可选)
+  - `knowledgePointId: UUID` (可选)
+  - `subject: String` (可选)
+  - `page: Int` (可选, 默认 0)
+  - `size: Int` (可选, 默认 20)
+- **响应**: `200 OK` - `PageVO<QuestionVO>`
+
+### 6.4 搜索题目
+- **Endpoint**: `POST /api/questions/search`
+- **请求 Body**: `QuestionSearchDto`
+  **Kotlin 定义**
+  ```kotlin
+  data class QuestionSearchDto(
+      val type: QuestionType?,
+      val difficulty: Difficulty?,
+      val knowledgePointIds: List<UUID>?,
+      val subject: String?,
+      val creatorId: UUID?,
+      val keyword: String?
+  )
+  ```
+  **JSON 示例**
+  ```json
+  {
+    "difficulty": "EASY",
+    "subject": "Kotlin Basics",
+    "keyword": "variable"
+  }
+  ```
+- **响应**: `200 OK` - `List<QuestionVO>`
+
+### 6.5 更新题目
+- **Endpoint**: `PUT /api/questions/{id}`
+- **路径参数**: `id: UUID`
+- **请求 Body**: `UpdateQuestionDto`
+  **Kotlin 定义**
+  ```kotlin
+  data class UpdateQuestionDto(
+      val type: QuestionType?,
+      val difficulty: Difficulty?,
+      val content: String?,
+      val correctAnswer: String?,
+      val explanation: String?,
+      val knowledgePointIds: Set<UUID>?
+  )
+  ```
+  **JSON 示例**
+  ```json
+  {
+    "difficulty": "MEDIUM",
+    "content": "What are the main keywords for variables in Kotlin?"
+  }
+  ```
+- **响应**: `200 OK` - `QuestionVO`
+
+### 6.6 删除题目
+- **Endpoint**: `DELETE /api/questions/{id}`
+- **路径参数**: `id: UUID`
+- **响应**: `204 No Content`
+
+### 6.7 获取题目统计
+- **Endpoint**: `GET /api/questions/stats`
+- **响应**: `200 OK` - `QuestionStatsVO`
+
+### 6.8 获取所有题目类型
+- **Endpoint**: `GET /api/questions/types`
+- **响应**: `200 OK` - `List<String>`
+
+### 6.9 获取所有难度等级
+- **Endpoint**: `GET /api/questions/difficulties`
+- **响应**: `200 OK` - `List<String>`
+
+### 响应/请求体定义
+- `QuestionVO`
+  **Kotlin 定义**
+  ```kotlin
+  data class QuestionVO(
+      val id: UUID,
+      val type: QuestionType,
+      val difficulty: Difficulty,
+      val content: String,
+      val explanation: String?,
+      val knowledgePoints: Set<KnowledgePointVO>,
+      val creator: UserVO?,
+      val createdAt: LocalDateTime?,
+      val updatedAt: LocalDateTime?
+  )
+  ```
+  **JSON 示例**
+  ```json
+  {
+    "id": "d3eebc99-9c0b-4ef8-bb6d-6bb9bd380a14",
+    "type": "SINGLE_CHOICE",
+    "difficulty": "EASY",
+    "content": "What is the keyword for a variable in Kotlin?",
+    "explanation": "`val` is for read-only variables, `var` is for mutable variables.",
+    "knowledgePoints": [
       {
-        "id": "string",
-        "title": "string",
-        "order": "number",
-        "content": "string",
-        "exercises": [Question对象],
-        "isCompleted": "boolean"
+        "id": "g6eebc99-9c0b-4ef8-bb6d-6bb9bd380a17",
+        "name": "Variables",
+        "description": "Kotlin variable declaration.",
+        "subject": "Kotlin Basics"
       }
     ],
-    "isGenerating": "boolean",
-    "progress": "number"
+    "creator": {
+      "id": "a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11",
+      "displayName": "Jane Doe",
+      "avatarUrl": "https://example.com/avatar.png",
+      "role": "TEACHER"
+    },
+    "createdAt": "2025-07-05T11:00:00Z",
+    "updatedAt": "2025-07-05T11:00:00Z"
+  }
+  ```
+- `QuestionStatsVO`
+  **Kotlin 定义**
+  ```kotlin
+  data class QuestionStatsVO(
+      val total: Int,
+      val byType: Map<QuestionType, Int>,
+      val byDifficulty: Map<Difficulty, Int>
+  )
+  ```
+  **JSON 示例**
+  ```json
+  {
+    "total": 150,
+    "byType": {
+      "SINGLE_CHOICE": 100,
+      "MULTIPLE_CHOICE": 50
+    },
+    "byDifficulty": {
+      "EASY": 70,
+      "MEDIUM": 50,
+      "HARD": 30
+    }
   }
   ```
 
-### 8. 学生分析 (Student Analysis)
+---
 
-#### 8.1 获取学生分析数据
-- **接口地址**: `GET /analysis`
-- **接口描述**: 获取学生学习分析数据
-- **请求参数**: 无
-- **响应格式**:
-  ```json
-  [
-    {
-      "id": "string",
-      "studentName": "string",
-      "incorrectQuestions": "string",
-      "errorLocation": "string",
-      "suggestedCorrection": "string"
-    }
-  ]
+## 7. 通知接口 (`NotificationController`)
+**基础路径**: `/api/notifications`
+
+### 7.1 发送通知
+- **Endpoint**: `POST /api/notifications`
+- **请求 Body**: `CreateNotificationDto`
+  **Kotlin 定义**
+  ```kotlin
+  data class CreateNotificationDto(
+      val title: String,
+      val content: String,
+      val type: NotificationType, // (SYSTEM, ASSIGNMENT, GRADE, MESSAGE)
+      val recipientId: UUID,
+      val senderId: UUID?
+  )
   ```
-
-### 9. 导航菜单 (Navigation Menu)
-
-#### 9.1 获取教师导航菜单
-- **接口地址**: `GET /menu/teacher`
-- **接口描述**: 获取教师角色的导航菜单
-- **请求参数**: 无
-- **响应格式**:
+  **JSON 示例**
   ```json
-  [
-    {
-      "id": "string",
-      "label": "string",
-      "icon": "string",
-      "path": "string",
-      "isActive": "boolean" (可选)
-    }
-  ]
+  {
+    "title": "New Assignment Published",
+    "content": "A new assignment has been published for 'Introduction to Kotlin'.",
+    "type": "ASSIGNMENT",
+    "recipientId": "b1eebc99-9c0b-4ef8-bb6d-6bb9bd380a12",
+    "senderId": "a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11"
+  }
   ```
+- **响应**: `201 Created` - `NotificationVO`
 
-#### 9.2 获取学生导航菜单
-- **接口地址**: `GET /menu/student`
-- **接口描述**: 获取学生角色的导航菜单
-- **请求参数**: 无
-- **响应格式**: 同上
-
-#### 9.3 获取管理员导航菜单
-- **接口地址**: `GET /menu/admin`
-- **接口描述**: 获取管理员角色的导航菜单
-- **请求参数**: 无
-- **响应格式**: 同上
-
-### 10. 资源管理 (Resource Management)
-
-#### 10.1 获取所有资源
-- **接口地址**: `GET /resources`
-- **接口描述**: 获取系统中所有学习资源
-- **请求参数**: 无
-- **响应格式**:
+### 7.2 广播通知
+- **Endpoint**: `POST /api/notifications/broadcast`
+- **请求 Body**: `BroadcastNotificationDto`
+  **Kotlin 定义**
+  ```kotlin
+  data class BroadcastNotificationDto(
+      val title: String,
+      val content: String,
+      val role: String, // e.g., "STUDENT", "TEACHER"
+      val type: NotificationType,
+      val senderId: UUID?
+  )
+  ```
+  **JSON 示例**
   ```json
-  [
-    {
-      "id": "string",
-      "title": "string",
-      "type": "video" | "document" | "image" | "assessment",
-      "subject": "string",
-      "uploader": "string",
-      "uploadDate": "string",
-      "thumbnail": "string" (可选)
-    }
-  ]
+  {
+    "title": "System Maintenance",
+    "content": "The system will be down for maintenance tonight.",
+    "role": "STUDENT",
+    "type": "SYSTEM",
+    "senderId": "a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11"
+  }
   ```
+- **响应**: `201 Created` - `List<NotificationVO>`
 
-## 错误处理
+### 7.3 获取用户通知
+- **Endpoint**: `GET /api/notifications/user/{userId}`
+- **路径参数**: `userId: UUID`
+- **查询参数**:
+  - `unreadOnly: Boolean` (可选, 默认 `false`)
+  - `type: NotificationType` (可选)
+- **响应**: `200 OK` - `List<NotificationVO>`
 
-所有接口在发生错误时都会返回相应的 HTTP 状态码和错误信息：
+### 7.4 获取用户通知摘要
+- **Endpoint**: `GET /api/notifications/user/{userId}/summary`
+- **路径参数**: `userId: UUID`
+- **响应**: `200 OK` - `NotificationSummaryVO`
 
-- **200**: 请求成功
-- **400**: 请求参数错误
-- **401**: 未授权访问
-- **403**: 权限不足
-- **404**: 资源不存在
-- **500**: 服务器内部错误
+### 7.5 标记为已读
+- **Endpoint**: `PUT /api/notifications/{id}/read`
+- **路径参数**: `id: UUID` (通知ID)
+- **查询参数**: `userId: UUID` (必需)
+- **响应**: `200 OK` - `NotificationVO`
 
-错误响应格式：
-```json
-{
-  "error": "错误类型",
-  "message": "错误详细信息"
-}
-```
+### 7.6 全部标记为已读
+- **Endpoint**: `PUT /api/notifications/user/{userId}/read-all`
+- **路径参数**: `userId: UUID`
+- **响应**: `200 OK` - `MessageVO`
 
-## 注意事项
+### 7.7 批量标记为已读
+- **Endpoint**: `POST /api/notifications/mark-read`
+- **请求 Body**: `MarkReadDto`
+  **Kotlin 定义**
+  ```kotlin
+  data class MarkReadDto(
+      val notificationIds: List<UUID>,
+      val userId: UUID
+  )
+  ```
+  **JSON 示例**
+  ```json
+  {
+    "notificationIds": [
+      "j9eebc99-9c0b-4ef8-bb6d-6bb9bd380a20",
+      "k0eebc99-9c0b-4ef8-bb6d-6bb9bd380a21"
+    ],
+    "userId": "b1eebc99-9c0b-4ef8-bb6d-6bb9bd380a12"
+  }
+  ```
+- **响应**: `200 OK` - `MessageVO`
 
-1. 所有接口均使用 JSON 格式进行数据交互
-2. 日期时间格式使用 ISO 8601 标准
-3. 所有字符串字段均使用 UTF-8 编码
-4. 接口返回的数据均为测试数据，实际使用时需要连接真实数据库
+### 7.8 删除通知
+- **Endpoint**: `DELETE /api/notifications/{id}`
+- **路径参数**: `id: UUID`
+- **查询参数**: `userId: UUID` (必需)
+- **响应**: `204 No Content`
+
+### 7.9 获取通知类型
+- **Endpoint**: `GET /api/notifications/types`
+- **响应**: `200 OK` - `List<String>`
+
+### 7.10 清理旧通知
+- **Endpoint**: `DELETE /api/notifications/cleanup`
+- **查询参数**: `daysOld: Int` (可选, 默认 30)
+- **响应**: `200 OK` - `MessageVO`
+
+### 7.11 获取通知统计
+- **Endpoint**: `GET /api/notifications/stats`
+- **响应**: `200 OK` - `NotificationStatsVO`
+
+### 响应/请求体定义
+- `NotificationVO`
+  **Kotlin 定义**
+  ```kotlin
+  data class NotificationVO(
+      val id: UUID,
+      val title: String,
+      val content: String,
+      val type: NotificationType,
+      val sender: UserVO?,
+      val recipient: UserVO,
+      val isRead: Boolean,
+      val readAt: LocalDateTime?,
+      val createdAt: LocalDateTime?
+  )
+  ```
+  **JSON 示例**
+  ```json
+  {
+    "id": "j9eebc99-9c0b-4ef8-bb6d-6bb9bd380a20",
+    "title": "New Assignment Published",
+    "content": "A new assignment has been published for 'Introduction to Kotlin'.",
+    "type": "ASSIGNMENT",
+    "sender": {
+      "id": "a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11",
+      "displayName": "Jane Doe",
+      "avatarUrl": "https://example.com/avatar.png",
+      "role": "TEACHER"
+    },
+    "recipient": {
+      "id": "b1eebc99-9c0b-4ef8-bb6d-6bb9bd380a12",
+      "displayName": "John Doe",
+      "avatarUrl": "https://example.com/avatar.png",
+      "role": "STUDENT"
+    },
+    "isRead": false,
+    "readAt": null,
+    "createdAt": "2025-07-08T15:00:00Z"
+  }
+  ```
+- `NotificationSummaryVO`
+  **Kotlin 定义**
+  ```kotlin
+  data class NotificationSummaryVO(
+      val totalCount: Long,
+      val unreadCount: Long,
+      val byType: Map<NotificationType, Long>
+  )
+  ```
+  **JSON 示例**
+  ```json
+  {
+    "totalCount": 10,
+    "unreadCount": 3,
+    "byType": {
+      "ASSIGNMENT": 5,
+      "GRADE": 2,
+      "SYSTEM": 3
+    }
+  }
+  ```
+- `NotificationStatsVO`
+  **Kotlin 定义**
+  ```kotlin
+  data class NotificationStatsVO(
+      val total: Int,
+      val byType: Map<NotificationType, Int>,
+      val readStatus: Map<String, Int> // e.g., {"read": 10, "unread": 5}
+  )
+  ```
+  **JSON 示例**
+  ```json
+  {
+    "total": 100,
+    "byType": {
+      "ASSIGNMENT": 50,
+      "GRADE": 20,
+      "SYSTEM": 30
+    },
+    "readStatus": {
+      "read": 80,
+      "unread": 20
+    }
+  }
+  ```

--- a/src/main/kotlin/edu/jimei/janus/application/service/StorageService.kt
+++ b/src/main/kotlin/edu/jimei/janus/application/service/StorageService.kt
@@ -1,0 +1,51 @@
+package edu.jimei.janus.application.service
+
+import edu.jimei.janus.domain.storage.StorageObject
+import edu.jimei.janus.domain.storage.StorageObjectRepository
+import edu.jimei.janus.domain.user.User
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.PageRequest
+import org.springframework.data.jpa.domain.Specification
+import org.springframework.stereotype.Service
+import java.util.*
+
+@Service
+class StorageService(
+    private val storageObjectRepository: StorageObjectRepository
+) {
+    fun getFiles(
+        uploaderId: UUID?,
+        keyword: String?,
+        page: Int,
+        size: Int,
+        currentUser: User
+    ): Page<StorageObject> {
+        val pageable = PageRequest.of(page, size)
+
+        val spec = Specification<StorageObject> { root, query, cb ->
+            val predicates = mutableListOf<jakarta.persistence.criteria.Predicate>()
+
+            // Role-based filtering for uploaderId
+            if (currentUser.role == "ADMIN") {
+                uploaderId?.let {
+                    predicates.add(cb.equal(root.get<User>("uploader").get<UUID>("id"), it))
+                }
+            } else {
+                predicates.add(cb.equal(root.get<User>("uploader").get<UUID>("id"), currentUser.id))
+            }
+
+            // Keyword filtering
+            keyword?.let {
+                if (it.isNotBlank()) {
+                    predicates.add(cb.like(root.get("originalFilename"), "%${it.trim()}%"))
+                }
+            }
+            
+            query.orderBy(cb.desc(root.get<Any>("createdAt")))
+
+            cb.and(*predicates.toTypedArray())
+        }
+
+        return storageObjectRepository.findAll(spec, pageable)
+    }
+} 

--- a/src/main/kotlin/edu/jimei/janus/controller/StorageController.kt
+++ b/src/main/kotlin/edu/jimei/janus/controller/StorageController.kt
@@ -1,9 +1,13 @@
 package edu.jimei.janus.controller
 
 import edu.jimei.janus.application.service.OssService
+import edu.jimei.janus.application.service.StorageService
 import edu.jimei.janus.controller.vo.StorageObjectVO
+import edu.jimei.janus.controller.vo.common.PageVO
 import edu.jimei.janus.controller.vo.common.StatusVO
+import edu.jimei.janus.controller.vo.common.toVo
 import edu.jimei.janus.controller.vo.toVo
+import edu.jimei.janus.domain.user.UserRepository
 import edu.jimei.janus.infrastructure.pulsar.FileProcessingProducer
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.*
@@ -14,7 +18,9 @@ import java.util.*
 @RequestMapping("/api/storage")
 class StorageController(
     private val ossService: OssService,
-    private val fileProcessingProducer: FileProcessingProducer
+    private val fileProcessingProducer: FileProcessingProducer,
+    private val storageService: StorageService,
+    private val userRepository: UserRepository
 ) {
 
     @PostMapping("/upload")
@@ -40,5 +46,23 @@ class StorageController(
     fun embedFile(@PathVariable id: UUID): ResponseEntity<StatusVO> {
         fileProcessingProducer.sendFileProcessingRequest(id)
         return ResponseEntity.accepted().body(StatusVO(status = "accepted", message = "File processing request accepted and queued."))
+    }
+
+    @GetMapping
+    fun getFiles(
+        // FIXME: This is a temporary solution for identifying the user.
+        // In a real-world application, user information should be obtained from a security context (e.g., Spring Security's AuthenticationPrincipal).
+        // This endpoint needs to be secured properly.
+        @RequestParam currentUserId: UUID,
+        @RequestParam(required = false) uploaderId: UUID?,
+        @RequestParam(required = false) keyword: String?,
+        @RequestParam(defaultValue = "0") page: Int,
+        @RequestParam(defaultValue = "20") size: Int
+    ): ResponseEntity<PageVO<StorageObjectVO>> {
+        val currentUser = userRepository.findById(currentUserId)
+            .orElseThrow { IllegalArgumentException("User with id $currentUserId not found") }
+
+        val filesPage = storageService.getFiles(uploaderId, keyword, page, size, currentUser)
+        return ResponseEntity.ok(filesPage.toVo { it.toVo() })
     }
 } 

--- a/src/main/kotlin/edu/jimei/janus/domain/storage/StorageObjectRepository.kt
+++ b/src/main/kotlin/edu/jimei/janus/domain/storage/StorageObjectRepository.kt
@@ -1,10 +1,11 @@
 package edu.jimei.janus.domain.storage
 
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor
 import org.springframework.stereotype.Repository
 import java.util.UUID
 
 @Repository
-interface StorageObjectRepository : JpaRepository<StorageObject, UUID> {
+interface StorageObjectRepository : JpaRepository<StorageObject, UUID>, JpaSpecificationExecutor<StorageObject> {
     fun findByObjectKey(objectKey: String): StorageObject?
 } 


### PR DESCRIPTION
Adds a new endpoint GET /api/storage to retrieve a paginated list of stored files.

- Implements filtering by uploader ID and filename keyword.
- Implements role-based access control where admins can see all files and regular users can only see their own.
- Adds StorageService to handle the business logic.
- Updates StorageObjectRepository to use JpaSpecificationExecutor for dynamic queries.

NOTE: Authentication is not yet implemented in the project. A temporary, insecure solution using a 'currentUserId' request parameter has been added, with a FIXME notice in the code and documentation.